### PR TITLE
Implement cancellable autoscroll using custom hook

### DIFF
--- a/reactGPT/src/components/Chat.jsx
+++ b/reactGPT/src/components/Chat.jsx
@@ -1,7 +1,8 @@
 import ReactMarkdown from 'react-markdown';
 import CodeHighlight from './utils/CodeHighlight';
+import { useAutoScroll } from './utils/AutoScroll';
 import PropTypes from "prop-types";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import "./Chat.css";
 
 Chat.propTypes = {
@@ -77,11 +78,22 @@ function Chat(props) {
     }
   };
 
+  // Hook usage
+  const { messagesEndRef, scrollCheck, scrollToBottom } = useAutoScroll();
+
+  useEffect(() => {
+      // Check if user has scrolled up
+  scrollCheck();
+
+    // Call on every messages update
+    scrollToBottom();
+  }, [messages, scrollCheck, scrollToBottom]);
+
   return (
     <div className="chat-container">
       <h1 className="heading">Canvas GPT</h1>
       <div className="chat-wrapper">
-        <div id="chat-messages" className="chat-box">
+        <div id="chat-messages" className="chat-box" ref={messagesEndRef} onScroll={scrollCheck}>
           {messages.map((message, index) => (
             <div
               key={index}

--- a/reactGPT/src/components/utils/AutoScroll.jsx
+++ b/reactGPT/src/components/utils/AutoScroll.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+export const useAutoScroll = () => {
+  // Ref for the chat box to control scroll position.
+  const messagesEndRef = useRef(null);
+  let autoScroll = useRef(true);
+
+  const scrollCheck = () => {
+    // Check if there are any messages 
+    if (!messagesEndRef.current) return;
+    // check scroll position and set autoScroll to false if user has scrolled up
+    const { scrollTop, clientHeight, scrollHeight } = messagesEndRef.current;
+    
+    // Autoscroll cancel buffer. Can be jerky when set at 50+ but 
+    // can't be set too low because it can cancel itself when streaming
+    const atBottom = scrollTop + clientHeight >= scrollHeight - 50; 
+    autoScroll.current = atBottom;
+  };
+
+  const scrollToBottom = () => {
+    // Auto-scroll if enabled and the chat box element exists.
+    if (autoScroll.current && messagesEndRef.current) {
+      window.requestAnimationFrame(() => {
+        messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+      });
+    }
+  };
+  
+  // Run scrollToBottom once when the component mounts.
+  useEffect(() => {
+    scrollToBottom();
+  }, []);
+
+  return { messagesEndRef, scrollCheck, scrollToBottom };
+};


### PR DESCRIPTION
closes #4 

This PR integrates a custom hook named `useAutoScroll` that encapsulates three main components: `scrollToBottom`, `scrollCheck`,  and `autoScroll` ref enabling auto-scrolling that can be cancelled as the user scrolls up and re-enabled if the user scrolls down.

1. The `scrollCheck` function, nested within the `useAutoScroll` hook, tracks the user's scroll position in the chat box. If the position is near the bottom, the `autoScroll` ref is updated to true and the scrollToBottom function gets invoked, pushing the chat box scroll position to the bottom.

2. The `scrollToBottom` function uses the `window.requestAnimationFrame` method to facilitate the smooth scroll transition, to navigate to the latest message.

3. An `onScroll` event handler is added to the chat box. When the user scrolls up, `scrollCheck` function toggles the `autoScroll` ref to false, pausing auto scroll functionality until the user scrolls back down.

This enhancement allows a smooth user experience, ensuring that as a long message streams in, the user can scroll up to stop the page from moving to be able to read the message text more easily. 