### PR TITLE
Improved AutoScroll, made cancelling and re-enabling smoother

### DIFF
--- a/reactGPT/src/components/Chat.jsx
+++ b/reactGPT/src/components/Chat.jsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import CodeHighlight from './utils/CodeHighlight';
 import { useAutoScroll } from './utils/AutoScroll';
 import PropTypes from "prop-types";
-import { useState, useEffect } from "react";
+import { useState, useLayoutEffect } from "react";
 import "./Chat.css";
 
 Chat.propTypes = {
@@ -81,7 +81,7 @@ function Chat(props) {
   // Hook usage
   const { messagesEndRef, scrollCheck, scrollToBottom } = useAutoScroll();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
       // Check if user has scrolled up
   scrollCheck();
 

--- a/reactGPT/src/components/utils/AutoScroll.jsx
+++ b/reactGPT/src/components/utils/AutoScroll.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 export const useAutoScroll = () => {
   // Ref for the chat box to control scroll position.
@@ -27,7 +27,7 @@ export const useAutoScroll = () => {
   };
   
   // Run scrollToBottom once when the component mounts.
-  useEffect(() => {
+  useLayoutEffect(() => {
     scrollToBottom();
   }, []);
 

--- a/reactGPT/src/components/utils/AutoScroll.jsx
+++ b/reactGPT/src/components/utils/AutoScroll.jsx
@@ -1,35 +1,45 @@
 import { useLayoutEffect, useRef } from "react";
 
 export const useAutoScroll = () => {
-  // Ref for the chat box to control scroll position.
-  const messagesEndRef = useRef(null);
-  let autoScroll = useRef(true);
+    // Ref for the chat box to control scroll position.
+    const messagesEndRef = useRef(null);
+    let autoScroll = useRef(true);
 
-  const scrollCheck = () => {
-    // Check if there are any messages 
-    if (!messagesEndRef.current) return;
-    // check scroll position and set autoScroll to false if user has scrolled up
-    const { scrollTop, clientHeight, scrollHeight } = messagesEndRef.current;
-    
-    // Autoscroll cancel buffer. Can be jerky when set at 50+ but 
-    // can't be set too low because it can cancel itself when streaming
-    const atBottom = scrollTop + clientHeight >= scrollHeight - 50; 
-    autoScroll.current = atBottom;
-  };
+    // Ref to store the last scroll top position.
+    const lastScrollTop = useRef(0);
 
-  const scrollToBottom = () => {
-    // Auto-scroll if enabled and the chat box element exists.
-    if (autoScroll.current && messagesEndRef.current) {
-      window.requestAnimationFrame(() => {
-        messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
-      });
-    }
-  };
-  
-  // Run scrollToBottom once when the component mounts.
-  useLayoutEffect(() => {
-    scrollToBottom();
-  }, []);
+    const scrollCheck = () => {
+        // Check if there are any messages 
+        if (!messagesEndRef.current) return;
 
-  return { messagesEndRef, scrollCheck, scrollToBottom };
+        const { scrollTop, clientHeight, scrollHeight } = messagesEndRef.current;
+
+        // If user scrolls up, turn off auto-scrolling.
+        if (scrollTop < lastScrollTop.current) {
+            autoScroll.current = false;
+        }
+        // If user scrolls to the bottom, turn on auto-scrolling.
+        else if (scrollTop + clientHeight >= scrollHeight) {
+            autoScroll.current = true;
+        }
+
+        // Update the last scroll top position.
+        lastScrollTop.current = scrollTop;
+    };
+
+    const scrollToBottom = () => {
+        // Auto-scroll if enabled and the chat box element exists.
+        if (autoScroll.current && messagesEndRef.current) {
+            window.requestAnimationFrame(() => {
+                messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+            });
+        }
+    };
+
+    // Run scrollToBottom once when the component mounts.
+    useLayoutEffect(() => {
+        scrollToBottom();
+    }, []);
+
+    return { messagesEndRef, scrollCheck, scrollToBottom };
 };

--- a/reactGPT/src/components/utils/AutoScroll.jsx
+++ b/reactGPT/src/components/utils/AutoScroll.jsx
@@ -11,21 +11,21 @@ export const useAutoScroll = () => {
     const scrollCheck = () => {
         // Check if there are any messages 
         if (!messagesEndRef.current) return;
-
+      
         const { scrollTop, clientHeight, scrollHeight } = messagesEndRef.current;
-
+        
         // If user scrolls up, turn off auto-scrolling.
         if (scrollTop < lastScrollTop.current) {
-            autoScroll.current = false;
+          autoScroll.current = false;
+        } 
+        // If user scrolls down and is within 100px of the bottom, turn on auto-scrolling.
+        else if (scrollTop > lastScrollTop.current && scrollTop + clientHeight >= scrollHeight - 100) {
+          autoScroll.current = true;
         }
-        // If user scrolls to the bottom, turn on auto-scrolling.
-        else if (scrollTop + clientHeight >= scrollHeight) {
-            autoScroll.current = true;
-        }
-
+      
         // Update the last scroll top position.
         lastScrollTop.current = scrollTop;
-    };
+      };
 
     const scrollToBottom = () => {
         // Auto-scroll if enabled and the chat box element exists.


### PR DESCRIPTION
Closes #7 

Adds an else if clause to ensure the buffer only takes effect when the user is scrolling down. Now auto scrolling, cancelling, and re-enabling is perfectly smooth. 

When re-enabling autoScroll by scrolling down it can sometimes be difficult if the message is still streaming in triggering autoScroll, this causes the user to sometimes miss the bottom when scrolling down because after scrolling a new line was added disabling auto scrolling.

This fixes that problem by using a buffer of 100px when the user scrolls down to re-enable autoscroll, this makes it super smooth to scroll back to bottom and continue autoscrolling as a new message comes is.